### PR TITLE
fix: serializer type name

### DIFF
--- a/event_store.go
+++ b/event_store.go
@@ -91,7 +91,7 @@ func WithKeyResolver(keyResolver KeyResolver) EventStoreOption {
 // WithEventSerializer sets an event serializer.
 //
 // - If you want to change the event serializer, specify an EventSerializer.
-// - The default is JsonEventSerializer.
+// - The default is DefaultEventSerializer.
 //
 // Returns an EventStoreOption.
 func WithEventSerializer(eventSerializer EventSerializer) EventStoreOption {
@@ -104,7 +104,7 @@ func WithEventSerializer(eventSerializer EventSerializer) EventStoreOption {
 // WithSnapshotSerializer sets a snapshot serializer.
 //
 // - If you want to change the snapshot serializer, specify a SnapshotSerializer.
-// - The default is JsonSnapshotSerializer.
+// - The default is DefaultSnapshotSerializer.
 //
 // Returns an EventStoreOption.
 func WithSnapshotSerializer(snapshotSerializer SnapshotSerializer) EventStoreOption {
@@ -157,8 +157,8 @@ func NewEventStore(
 		1,
 		math.MaxInt64,
 		&DefaultKeyResolver{},
-		&JsonEventSerializer{},
-		&JsonSnapshotSerializer{},
+		&DefaultEventSerializer{},
+		&DefaultSnapshotSerializer{},
 	}
 	for _, option := range options {
 		if err := option(es); err != nil {

--- a/serializer.go
+++ b/serializer.go
@@ -2,9 +2,9 @@ package event_store_adapter_go
 
 import "encoding/json"
 
-type JsonEventSerializer struct{}
+type DefaultEventSerializer struct{}
 
-func (s *JsonEventSerializer) Serialize(event Event) ([]byte, error) {
+func (s *DefaultEventSerializer) Serialize(event Event) ([]byte, error) {
 	result, err := json.Marshal(event)
 	if err != nil {
 		return nil, &SerializationError{EventStoreBaseError{"Failed to serialize the event", err}}
@@ -12,7 +12,7 @@ func (s *JsonEventSerializer) Serialize(event Event) ([]byte, error) {
 	return result, nil
 }
 
-func (s *JsonEventSerializer) Deserialize(data []byte, eventMap *map[string]interface{}) error {
+func (s *DefaultEventSerializer) Deserialize(data []byte, eventMap *map[string]interface{}) error {
 	err := json.Unmarshal(data, eventMap)
 	if err != nil {
 		return &DeserializationError{EventStoreBaseError{"Failed to deserialize the event", err}}
@@ -20,9 +20,9 @@ func (s *JsonEventSerializer) Deserialize(data []byte, eventMap *map[string]inte
 	return nil
 }
 
-type JsonSnapshotSerializer struct{}
+type DefaultSnapshotSerializer struct{}
 
-func (s *JsonSnapshotSerializer) Serialize(aggregate Aggregate) ([]byte, error) {
+func (s *DefaultSnapshotSerializer) Serialize(aggregate Aggregate) ([]byte, error) {
 	result, err := json.Marshal(aggregate)
 	if err != nil {
 		return nil, &SerializationError{EventStoreBaseError{"Failed to serialize the snapshot", err}}
@@ -30,7 +30,7 @@ func (s *JsonSnapshotSerializer) Serialize(aggregate Aggregate) ([]byte, error) 
 	return result, nil
 }
 
-func (s *JsonSnapshotSerializer) Deserialize(data []byte, aggregateMap *map[string]interface{}) error {
+func (s *DefaultSnapshotSerializer) Deserialize(data []byte, aggregateMap *map[string]interface{}) error {
 	err := json.Unmarshal(data, aggregateMap)
 	if err != nil {
 		return &DeserializationError{EventStoreBaseError{"Failed to deserialize the snapshot", err}}


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Refactor: Updated the default serialization methods in our event store. The previous `JsonEventSerializer` and `JsonSnapshotSerializer` have been renamed and replaced with `DefaultEventSerializer` and `DefaultSnapshotSerializer`. 

This change is primarily a renaming to reflect a more generic default serializer. It doesn't introduce new features or alter the existing functionality, but it does make the codebase more intuitive and easier to understand for developers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

---
- Refactor: Renamed `JsonEventSerializer` to `DefaultEventSerializer` and `JsonSnapshotSerializer` to `DefaultSnapshotSerializer` for clarity and consistency. 
- Refactor: Updated the default serializer names in the `NewEventStore` function to reflect these changes.
- No changes have been made to the logic or functionality of the methods, ensuring existing behavior remains intact.
---
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->